### PR TITLE
[wip] Attempts to fix: https://github.com/bluelabsio/s3-stream/issues/2

### DIFF
--- a/s3-stream/src/main/scala/com/bluelabs/s3stream/HttpRequests.scala
+++ b/s3-stream/src/main/scala/com/bluelabs/s3stream/HttpRequests.scala
@@ -4,14 +4,17 @@ import akka.http.scaladsl.marshallers.xml.ScalaXmlSupport._
 import akka.http.scaladsl.marshalling.Marshal
 import akka.http.scaladsl.model.Uri.Query
 import akka.http.scaladsl.model.headers.Host
+import akka.http.scaladsl.model.headers.RawHeader
 import akka.http.scaladsl.model.{HttpMethods, HttpRequest, RequestEntity, Uri}
 import akka.util.ByteString
 
 import scala.concurrent.{ExecutionContext, Future}
 
 object HttpRequests {
-  def initiateMultipartUploadRequest(s3Location: S3Location): HttpRequest = {
-    HttpRequest(method = HttpMethods.POST)
+  def initiateMultipartUploadRequest(s3Location: S3Location, metadata: Metadata): HttpRequest = {
+    val contentType = RawHeader("Content-Type", metadata.contentType)
+
+    HttpRequest(method = HttpMethods.POST, headers = List(contentType))
       .withHeaders(Host(requestHost(s3Location)))
       .withUri(requestUri(s3Location).withQuery(Query("uploads")))
   }

--- a/s3-stream/src/main/scala/com/bluelabs/s3stream/Metadata.scala
+++ b/s3-stream/src/main/scala/com/bluelabs/s3stream/Metadata.scala
@@ -1,0 +1,3 @@
+package com.bluelabs.s3stream
+
+case class Metadata(contentType: String = "binary/octet-stream")


### PR DESCRIPTION
# What

Add a metadata class to the relevant signatures so that we can set contentType in the initial HTTP request to amazon. `Metadata` is being passed instead of just contentType to make way for more options to be set in the future
# Why
- Setting the ContentType can be important for various application use-cases and having to perform subsequent HTTP requests to set it is not in the spirit of efficiency that a streaming library should strive for.
- https://github.com/bluelabsio/s3-stream/issues/2
