### PR TITLE
Add regular put for small uploads

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   // Versions
-  lazy val akkaVersion = "2.4.3"
+  lazy val akkaVersion = "2.4.9"
   lazy val scalatestVersion = "2.2.6"
 
   val akka = "com.typesafe.akka" %% "akka-actor" % akkaVersion

--- a/s3-stream/src/main/scala/com/bluelabs/s3stream/HttpRequests.scala
+++ b/s3-stream/src/main/scala/com/bluelabs/s3stream/HttpRequests.scala
@@ -3,7 +3,7 @@ package com.bluelabs.s3stream
 import akka.http.scaladsl.marshallers.xml.ScalaXmlSupport._
 import akka.http.scaladsl.marshalling.Marshal
 import akka.http.scaladsl.model.Uri.Query
-import akka.http.scaladsl.model.headers.Host
+import akka.http.scaladsl.model.headers.{Host, RawHeader}
 import akka.http.scaladsl.model.{HttpMethods, HttpRequest, RequestEntity, Uri}
 import akka.util.ByteString
 
@@ -37,6 +37,16 @@ object HttpRequests {
         .withUri(requestUri(upload.s3Location).withQuery(Query("uploadId" -> upload.uploadId)))
         .withEntity(entity)
     }
+  }
+
+  def putObject[T](s3Location: S3Location, data: ByteString, md5: Option[String] = None): HttpRequest = {
+    val headers = if (md5.isDefined)
+      List(Host(requestHost(s3Location)), RawHeader("Content-MD5", md5.get))
+    else
+      List(Host(requestHost(s3Location)))
+    HttpRequest(method = HttpMethods.PUT, headers = headers)
+      .withUri(requestUri(s3Location))
+      .withEntity(data)
   }
 
 

--- a/s3-stream/src/test/scala/com/bluelabs/s3stream/IntegrationSpec.scala
+++ b/s3-stream/src/test/scala/com/bluelabs/s3stream/IntegrationSpec.scala
@@ -1,0 +1,49 @@
+package com.bluelabs.s3stream
+
+import akka.actor.ActorSystem
+import akka.stream.{ActorMaterializer, ActorMaterializerSettings}
+import akka.testkit.TestKit
+import akka.util.ByteString
+import com.bluelabs.akkaaws.AWSCredentials
+import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+import scala.language.postfixOps
+
+/**
+  * Created by Jason Martens <jason.martens@3dr.com> on 9/1/16.
+  */
+class IntegrationSpec(_system: ActorSystem) extends TestKit(_system) with FlatSpecLike with Matchers with BeforeAndAfterAll {
+  def this() = this(ActorSystem("IntegrationSpec"))
+  implicit val materializer = ActorMaterializer(ActorMaterializerSettings(system).withDebugLogging(true))
+  // This bucket has open access, but deletes everything after 1 day
+  val bucketName = "3dr-publictest"
+  val creds = AWSCredentials("", "")
+  val stream: S3Stream = new S3Stream(creds)
+
+  "s3stream" should "upload small files with a simple put" in {
+    val bs = ByteString("Hello World")
+    Await.ready(stream.putObject(S3Location(bucketName, "helloworld.txt"), bs), 10 seconds)
+  }
+
+  it should "validate the MD5" in {
+    val data = ByteString("Check Integrity!")
+    val digest = java.security.MessageDigest.getInstance("MD5").digest(data.toArray[Byte])
+    val base64 = new sun.misc.BASE64Encoder().encode(digest)
+    Await.ready(stream.putObject(S3Location(bucketName, "checkintegrity.txt"), data, Some(base64)), 10 seconds)
+  }
+
+  it should "fail if the MD5 is invalid" in {
+    val data = ByteString("DEADBEEFDEADBEEFDEADBEEF")
+    val s3location = S3Location(bucketName, "nope.txt")
+    intercept[UploadFailedException] {
+      Await.result(stream.putObject(s3location, data, Some("Q2hlY2sgSW50ZWdyaXR5IQ==")), 10 seconds)
+    }
+  }
+
+  override def afterAll(): Unit = {
+    system.terminate()
+  }
+
+}


### PR DESCRIPTION
Note: response.discardEntityBytes() is in a newer version of Akka, can remove if we want to keep backward compatibility. 
