### PR TITLE
Add server side encryption and `Content-Type` support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,11 @@ project/plugins/project/
 # Scala-IDE specific
 .scala_dependencies
 .worksheet
+
+# IntelliJ Idea specific
+/.idea/
+/idea_modules/
+*.iml
+
+# MacOSX specific
+.DS_Store

--- a/akka-http-aws/src/main/scala/com/bluelabs/akkaaws/AwsHeaders.scala
+++ b/akka-http-aws/src/main/scala/com/bluelabs/akkaaws/AwsHeaders.scala
@@ -2,14 +2,17 @@ package com.bluelabs.akkaaws
 
 import akka.http.scaladsl.model.headers.{ModeledCustomHeaderCompanion, ModeledCustomHeader}
 
+import scala.util.parsing.json.JSON
 import scala.util.{Failure, Success, Try}
-
 
 object AwsHeaders {
 
   sealed abstract class ServerSideEncryptionAlgorithm(val name: String)
+
   object ServerSideEncryptionAlgorithm {
+
     case object AES256 extends ServerSideEncryptionAlgorithm("AES256")
+
     case object KMS extends ServerSideEncryptionAlgorithm("aws:kms")
 
     def fromString(raw: String): Try[ServerSideEncryptionAlgorithm] = raw match {
@@ -21,6 +24,7 @@ object AwsHeaders {
 
   object `X-Amz-Server-Side-Encryption` extends ModeledCustomHeaderCompanion[`X-Amz-Server-Side-Encryption`] {
     override def name: String = "X-Amz-Server-Side-Encryption"
+
     override def parse(value: String): Try[`X-Amz-Server-Side-Encryption`] =
       ServerSideEncryptionAlgorithm.fromString(value).map(new `X-Amz-Server-Side-Encryption`(_))
   }
@@ -38,6 +42,7 @@ object AwsHeaders {
 
   object `X-Amz-Server-Side-Encryption-Aws-Kms-Key-Id` extends ModeledCustomHeaderCompanion[`X-Amz-Server-Side-Encryption-Aws-Kms-Key-Id`] {
     override def name: String = "X-Amz-Server-Side-Encryption-Aws-Kms-Key-Id"
+
     override def parse(value: String): Try[`X-Amz-Server-Side-Encryption-Aws-Kms-Key-Id`] =
       Success(new `X-Amz-Server-Side-Encryption-Aws-Kms-Key-Id`(value))
   }
@@ -53,6 +58,31 @@ object AwsHeaders {
     override def renderInRequests(): Boolean = true
   }
 
-  // TODO add `x-amz-server-side-encryption-context` header.
+  object `X-Amz-Server-Side-Encryption-Context` extends ModeledCustomHeaderCompanion[`X-Amz-Server-Side-Encryption-Context`] {
+    override def name: String = "X-Amz-Server-Side-Encryption-Context"
+
+    override def parse(value: String): Try[`X-Amz-Server-Side-Encryption-Context`] =
+      JSON.parseFull(value) match {
+        case Some(context: Map[String, Any]) if context.forall(_._2.isInstanceOf[String]) =>
+          Success(new `X-Amz-Server-Side-Encryption-Context`(context.asInstanceOf[Map[String, String]]))
+        case _ =>
+          Failure(new IllegalArgumentException("$value is not a valid AWS KMS context"))
+      }
+  }
+
+  final case class `X-Amz-Server-Side-Encryption-Context`(context: Map[String, String]) extends ModeledCustomHeader[`X-Amz-Server-Side-Encryption-Context`] {
+
+    override def companion: ModeledCustomHeaderCompanion[`X-Amz-Server-Side-Encryption-Context`] = `X-Amz-Server-Side-Encryption-Context`
+
+    override def value(): String =
+      context.map { case (key, value) => s""""$key":"$value"""" }.mkString("{", ",", "}")
+
+    override def renderInResponses(): Boolean = true
+
+    override def renderInRequests(): Boolean = true
+  }
+
 
 }
+
+

--- a/akka-http-aws/src/main/scala/com/bluelabs/akkaaws/AwsHeaders.scala
+++ b/akka-http-aws/src/main/scala/com/bluelabs/akkaaws/AwsHeaders.scala
@@ -1,0 +1,58 @@
+package com.bluelabs.akkaaws
+
+import akka.http.scaladsl.model.headers.{ModeledCustomHeaderCompanion, ModeledCustomHeader}
+
+import scala.util.{Failure, Success, Try}
+
+
+object AwsHeaders {
+
+  sealed abstract class ServerSideEncryptionAlgorithm(val name: String)
+  object ServerSideEncryptionAlgorithm {
+    case object AES256 extends ServerSideEncryptionAlgorithm("AES256")
+    case object KMS extends ServerSideEncryptionAlgorithm("aws:kms")
+
+    def fromString(raw: String): Try[ServerSideEncryptionAlgorithm] = raw match {
+      case "AES256" => Success(AES256)
+      case "aws:kms" => Success(KMS)
+      case invalid => Failure(new IllegalArgumentException(s"$invalid is not a valid server side encryption algorithm."))
+    }
+  }
+
+  object `X-Amz-Server-Side-Encryption` extends ModeledCustomHeaderCompanion[`X-Amz-Server-Side-Encryption`] {
+    override def name: String = "X-Amz-Server-Side-Encryption"
+    override def parse(value: String): Try[`X-Amz-Server-Side-Encryption`] =
+      ServerSideEncryptionAlgorithm.fromString(value).map(new `X-Amz-Server-Side-Encryption`(_))
+  }
+
+  final case class `X-Amz-Server-Side-Encryption`(algorithm: ServerSideEncryptionAlgorithm) extends ModeledCustomHeader[`X-Amz-Server-Side-Encryption`] {
+
+    override def companion: ModeledCustomHeaderCompanion[`X-Amz-Server-Side-Encryption`] = `X-Amz-Server-Side-Encryption`
+
+    override def value(): String = algorithm.name
+
+    override def renderInResponses(): Boolean = true
+
+    override def renderInRequests(): Boolean = true
+  }
+
+  object `X-Amz-Server-Side-Encryption-Aws-Kms-Key-Id` extends ModeledCustomHeaderCompanion[`X-Amz-Server-Side-Encryption-Aws-Kms-Key-Id`] {
+    override def name: String = "X-Amz-Server-Side-Encryption-Aws-Kms-Key-Id"
+    override def parse(value: String): Try[`X-Amz-Server-Side-Encryption-Aws-Kms-Key-Id`] =
+      Success(new `X-Amz-Server-Side-Encryption-Aws-Kms-Key-Id`(value))
+  }
+
+  final case class `X-Amz-Server-Side-Encryption-Aws-Kms-Key-Id`(id: String) extends ModeledCustomHeader[`X-Amz-Server-Side-Encryption-Aws-Kms-Key-Id`] {
+
+    override def companion: ModeledCustomHeaderCompanion[`X-Amz-Server-Side-Encryption-Aws-Kms-Key-Id`] = `X-Amz-Server-Side-Encryption-Aws-Kms-Key-Id`
+
+    override def value(): String = id
+
+    override def renderInResponses(): Boolean = true
+
+    override def renderInRequests(): Boolean = true
+  }
+
+  // TODO add `x-amz-server-side-encryption-context` header.
+
+}

--- a/akka-http-aws/src/test/scala/com/bluelabs/akkaaws/AwsHeadersSpec.scala
+++ b/akka-http-aws/src/test/scala/com/bluelabs/akkaaws/AwsHeadersSpec.scala
@@ -2,7 +2,7 @@ package com.bluelabs.akkaaws
 
 import akka.http.scaladsl.model.headers.RawHeader
 import com.bluelabs.akkaaws.AwsHeaders.ServerSideEncryptionAlgorithm.AES256
-import com.bluelabs.akkaaws.AwsHeaders.{`X-Amz-Server-Side-Encryption-Aws-Kms-Key-Id`, `X-Amz-Server-Side-Encryption`, ServerSideEncryptionAlgorithm}
+import com.bluelabs.akkaaws.AwsHeaders.{`X-Amz-Server-Side-Encryption-Context`, `X-Amz-Server-Side-Encryption-Aws-Kms-Key-Id`, `X-Amz-Server-Side-Encryption`, ServerSideEncryptionAlgorithm}
 import org.scalatest.{FlatSpec, Matchers}
 
 import scala.util.{Failure, Success}
@@ -42,6 +42,29 @@ class AwsHeadersSpec extends FlatSpec with Matchers {
     val RawHeader(key, value) = `X-Amz-Server-Side-Encryption-Aws-Kms-Key-Id`("myId")
     key shouldBe "X-Amz-Server-Side-Encryption-Aws-Kms-Key-Id"
     value shouldBe "myId"
+  }
+
+  "`X-Amz-Server-Side-Encryption-Context`" should "parse context" in {
+    val expectedContext = Map("foo"->"bar", "foo2"->"bar2")
+    val `X-Amz-Server-Side-Encryption-Context`(context) = `X-Amz-Server-Side-Encryption-Context`(expectedContext)
+
+    context shouldBe expectedContext
+  }
+
+  it should "set the X-Amz-Server-Side-Encryption-Context header" in {
+    val RawHeader(key, value) = `X-Amz-Server-Side-Encryption-Context`(Map("foo"->"bar", "foo2"->"bar2"))
+    key shouldBe "X-Amz-Server-Side-Encryption-Context"
+    value shouldBe """{"foo":"bar","foo2":"bar2"}"""
+  }
+
+  it should "parse the raw context" in {
+    val header = `X-Amz-Server-Side-Encryption-Context`.parse("""{"foo":"bar","foo2":"bar2"}""")
+    header shouldBe Success(`X-Amz-Server-Side-Encryption-Context`(Map("foo"->"bar", "foo2"->"bar2")))
+  }
+
+  it should "not parse the raw context if it is not string->string" in {
+    val header = `X-Amz-Server-Side-Encryption-Context`.parse("""{"foo":"bar","foo2":2}""")
+    header shouldBe a[Failure[_]]
   }
 
 }

--- a/akka-http-aws/src/test/scala/com/bluelabs/akkaaws/AwsHeadersSpec.scala
+++ b/akka-http-aws/src/test/scala/com/bluelabs/akkaaws/AwsHeadersSpec.scala
@@ -1,0 +1,47 @@
+package com.bluelabs.akkaaws
+
+import akka.http.scaladsl.model.headers.RawHeader
+import com.bluelabs.akkaaws.AwsHeaders.ServerSideEncryptionAlgorithm.AES256
+import com.bluelabs.akkaaws.AwsHeaders.{`X-Amz-Server-Side-Encryption-Aws-Kms-Key-Id`, `X-Amz-Server-Side-Encryption`, ServerSideEncryptionAlgorithm}
+import org.scalatest.{FlatSpec, Matchers}
+
+import scala.util.{Failure, Success}
+
+
+class AwsHeadersSpec extends FlatSpec with Matchers {
+
+  "ServerSideEncryptionAlgorithm" should "parse AES256" in {
+    ServerSideEncryptionAlgorithm.fromString("AES256") shouldBe Success(ServerSideEncryptionAlgorithm.AES256)
+  }
+
+  it should "parse KMS" in {
+    ServerSideEncryptionAlgorithm.fromString("aws:kms") shouldBe Success(ServerSideEncryptionAlgorithm.KMS)
+  }
+
+  it should "not parse an unsupported algorithm" in {
+    ServerSideEncryptionAlgorithm.fromString("Zip War AirGanon") shouldBe a[Failure[_]]
+  }
+
+  "`X-Amz-Server-Side-Encryption`" should "parse AES256 algorithm" in {
+    val `X-Amz-Server-Side-Encryption`(algorithm) = `X-Amz-Server-Side-Encryption`("AES256")
+    algorithm shouldBe AES256
+  }
+
+  it should "set the X-Amz-Server-Side-Encryption header" in {
+    val RawHeader(key, value) = `X-Amz-Server-Side-Encryption`("AES256")
+    key shouldBe "X-Amz-Server-Side-Encryption"
+    value shouldBe "AES256"
+  }
+
+  "`X-Amz-Server-Side-Encryption-Aws-Kms-Key-Id`" should "parse kms key id" in {
+    val `X-Amz-Server-Side-Encryption-Aws-Kms-Key-Id`(id) = `X-Amz-Server-Side-Encryption-Aws-Kms-Key-Id`("myId")
+    id shouldBe "myId"
+  }
+
+  it should "set the X-Amz-Server-Side-Encryption-Aws-Kms-Key-Id header" in {
+    val RawHeader(key, value) = `X-Amz-Server-Side-Encryption-Aws-Kms-Key-Id`("myId")
+    key shouldBe "X-Amz-Server-Side-Encryption-Aws-Kms-Key-Id"
+    value shouldBe "myId"
+  }
+
+}

--- a/s3-stream/src/main/scala/com/bluelabs/s3stream/HttpRequests.scala
+++ b/s3-stream/src/main/scala/com/bluelabs/s3stream/HttpRequests.scala
@@ -31,12 +31,15 @@ object HttpRequests {
     metadata.serverSideEncryption match {
       case ServerSideEncryption.Aes256 =>
         List(new `X-Amz-Server-Side-Encryption`(AES256))
-      case ServerSideEncryption.Kms(keyId) =>
+      case ServerSideEncryption.Kms(keyId, context) =>
         List(
           new `X-Amz-Server-Side-Encryption`(KMS),
           new `X-Amz-Server-Side-Encryption-Aws-Kms-Key-Id`(keyId)
-          // TODO add `x-amz-server-side-encryption-context` header.
-        )
+        ) ++ (if(context.isEmpty) {
+          List.empty
+        } else {
+          List(`X-Amz-Server-Side-Encryption-Context`(context))
+        })
       case ServerSideEncryption.None =>
         Nil
     }

--- a/s3-stream/src/main/scala/com/bluelabs/s3stream/S3Stream.scala
+++ b/s3-stream/src/main/scala/com/bluelabs/s3stream/S3Stream.scala
@@ -20,6 +20,11 @@ import akka.stream.{Attributes, Materializer}
 import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
 import akka.util.ByteString
 
+case class Metadata(
+  contentType: ContentType = ContentTypes.`application/octet-stream`,
+  serverSideEncryption: ServerSideEncryption = ServerSideEncryption.None
+)
+
 case class S3Location(bucket: String, key: String)
 
 case class MultipartUpload(s3Location: S3Location, uploadId: String)
@@ -56,18 +61,18 @@ class S3Stream(credentials: AWSCredentials, region: String = "us-east-1")(implic
     * @param chunkingParallelism
     * @return
     */
-  def multipartUpload(s3Location: S3Location, chunkSize: Int = MIN_CHUNK_SIZE, chunkingParallelism: Int = 4): Sink[ByteString, Future[CompleteMultipartUploadResult]] = {
+  def multipartUpload(s3Location: S3Location, chunkSize: Int = MIN_CHUNK_SIZE, chunkingParallelism: Int = 4, metadata: Metadata = Metadata()): Sink[ByteString, Future[CompleteMultipartUploadResult]] = {
     import mat.executionContext
 
-    chunkAndRequest(s3Location, chunkSize)(chunkingParallelism)
+    chunkAndRequest(s3Location, chunkSize, metadata)(chunkingParallelism)
       .log("s3-upload-response").withAttributes(Attributes.logLevels(onElement = Logging.DebugLevel, onFailure = Logging.WarningLevel, onFinish = Logging.InfoLevel))
       .toMat(completionSink(s3Location))(Keep.right)
   }
 
-  def initiateMultipartUpload(s3Location: S3Location): Future[MultipartUpload] = {
+  def initiateMultipartUpload(s3Location: S3Location, metadata: Metadata): Future[MultipartUpload] = {
     import mat.executionContext
 
-    val req = HttpRequests.initiateMultipartUploadRequest(s3Location)
+    val req = HttpRequests.initiateMultipartUploadRequest(s3Location, metadata)
     val response = for {
       signedReq <- Signer.signedRequest(req, signingKey)
       response <- Http().singleRequest(signedReq)
@@ -99,8 +104,9 @@ class S3Stream(credentials: AWSCredentials, region: String = "us-east-1")(implic
     * @param s3Location The s3 location to which to upload to
     * @return
     */
-  def initiateUpload(s3Location: S3Location): Source[(MultipartUpload, Int), NotUsed] = {
-    Source.single(s3Location).mapAsync(1)(initiateMultipartUpload(_))
+  def initiateUpload(s3Location: S3Location, metadata: Metadata): Source[(MultipartUpload, Int), NotUsed] = {
+    Source.single(s3Location)
+      .mapAsync(1)(initiateMultipartUpload(_, metadata))
       .mapConcat{case r => Stream.continually(r)}
       .zip(StreamUtils.counter(1))
   }
@@ -113,17 +119,17 @@ class S3Stream(credentials: AWSCredentials, region: String = "us-east-1")(implic
     * @param parallelism
     * @return
     */
-  def createRequests(s3Location: S3Location, chunkSize: Int = MIN_CHUNK_SIZE, parallelism: Int = 4): Flow[ByteString, (HttpRequest, (MultipartUpload, Int)), NotUsed] = {
+  def createRequests(s3Location: S3Location, chunkSize: Int = MIN_CHUNK_SIZE, parallelism: Int = 4, metadata: Metadata = Metadata()): Flow[ByteString, (HttpRequest, (MultipartUpload, Int)), NotUsed] = {
     assert(chunkSize >= MIN_CHUNK_SIZE, "Chunk size must be at least 5242880B. See http://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadUploadPart.html")
-    val requestInfo: Source[(MultipartUpload, Int), NotUsed] = initiateUpload(s3Location)
+    val requestInfo: Source[(MultipartUpload, Int), NotUsed] = initiateUpload(s3Location, metadata)
     Flow[ByteString]
       .via(new Chunker(chunkSize))
-      .zipWith(requestInfo){case (payload, (uploadInfo, chunkIndex)) => (HttpRequests.uploadPartRequest(uploadInfo, chunkIndex, payload), (uploadInfo, chunkIndex))}
+      .zipWith(requestInfo){case (payload, (uploadInfo, chunkIndex)) => (HttpRequests.uploadPartRequest(uploadInfo, chunkIndex, payload, metadata), (uploadInfo, chunkIndex))}
       .mapAsync(parallelism){case (req, info) => Signer.signedRequest(req, signingKey).zip(Future.successful(info)) }
   }
 
-  def chunkAndRequest(s3Location: S3Location, chunkSize: Int = MIN_CHUNK_SIZE)(parallelism: Int = 4): Flow[ByteString, UploadPartResponse, NotUsed] = {
-    createRequests(s3Location, chunkSize, parallelism)
+  def chunkAndRequest(s3Location: S3Location, chunkSize: Int = MIN_CHUNK_SIZE, metadata: Metadata = Metadata())(parallelism: Int = 4): Flow[ByteString, UploadPartResponse, NotUsed] = {
+    createRequests(s3Location, chunkSize, parallelism, metadata)
       .via(Http().superPool[(MultipartUpload, Int)]())
         .map {
           case (Success(r), (upload, index)) => {

--- a/s3-stream/src/main/scala/com/bluelabs/s3stream/ServerSideEncryption.scala
+++ b/s3-stream/src/main/scala/com/bluelabs/s3stream/ServerSideEncryption.scala
@@ -1,0 +1,14 @@
+package com.bluelabs.s3stream
+
+
+sealed trait ServerSideEncryption
+
+object ServerSideEncryption {
+
+  case object None extends ServerSideEncryption
+
+  case object Aes256 extends ServerSideEncryption
+
+  // TODO add context
+  case class Kms(keyId: String) extends ServerSideEncryption
+}

--- a/s3-stream/src/main/scala/com/bluelabs/s3stream/ServerSideEncryption.scala
+++ b/s3-stream/src/main/scala/com/bluelabs/s3stream/ServerSideEncryption.scala
@@ -9,6 +9,5 @@ object ServerSideEncryption {
 
   case object Aes256 extends ServerSideEncryption
 
-  // TODO add context
-  case class Kms(keyId: String) extends ServerSideEncryption
+  case class Kms(keyId: String, context: Map[String, String] = Map.empty) extends ServerSideEncryption
 }

--- a/s3-stream/src/test/scala/com/bluelabs/s3stream/HttpRequestsSpec.scala
+++ b/s3-stream/src/test/scala/com/bluelabs/s3stream/HttpRequestsSpec.scala
@@ -1,0 +1,66 @@
+package com.bluelabs.s3stream
+
+import akka.http.scaladsl.model.ContentTypes
+import akka.http.scaladsl.model.headers.`Content-Type`
+import akka.util.ByteString
+import com.bluelabs.akkaaws.AwsHeaders.ServerSideEncryptionAlgorithm.{KMS, AES256}
+
+import org.scalatest.{Matchers, FlatSpec}
+
+class HttpRequestsSpec extends FlatSpec with Matchers {
+
+  import HttpRequests._
+  import com.bluelabs.akkaaws.AwsHeaders._
+
+  "metadataHeaders" should "not add the contentType header when contentType is default" in {
+    metadataHeaders(Metadata()) should not contain `Content-Type`(ContentTypes.`application/octet-stream`)
+  }
+
+  it should "not add the contentType header contentType is custom" in {
+    val customContentType = ContentTypes.`application/json`
+    metadataHeaders(Metadata(customContentType)) should not contain `Content-Type`(customContentType)
+  }
+
+  it should "not add the x-amz-server-side-encryption header when the server side encryption is None" in {
+    metadataHeaders(Metadata(serverSideEncryption = ServerSideEncryption.None)) should not contain a[`X-Amz-Server-Side-Encryption`]
+  }
+
+  it should "add the x-amz-server-side-encryption with AES256 header when the server side encryption is AES256" in {
+    metadataHeaders(Metadata(serverSideEncryption = ServerSideEncryption.Aes256)) should contain(`X-Amz-Server-Side-Encryption`(AES256))
+  }
+
+  it should "add the x-amz-server-side-encryption with KMZ header when the server side encryption is KMS" in {
+    metadataHeaders(Metadata(serverSideEncryption = ServerSideEncryption.Kms("my-id"))) should contain(`X-Amz-Server-Side-Encryption`(KMS))
+  }
+
+  it should "add the x-amz-server-side-encryption-kms-id with KMZ header when the server side encryption is KMS" in {
+    metadataHeaders(Metadata(serverSideEncryption = ServerSideEncryption.Kms("my-id"))) should contain(`X-Amz-Server-Side-Encryption-Aws-Kms-Key-Id`("my-id"))
+  }
+
+  "initiateMultipartUploadRequest" should "set the default entity contentType when it is not specified" in {
+    val requestEntity = initiateMultipartUploadRequest(S3Location("test-bucket", "test-key"), Metadata()).entity
+
+    requestEntity.contentType shouldBe ContentTypes.`application/octet-stream`
+  }
+
+  it should "set the custom entity contentType when it is specified" in {
+    val customContentType = ContentTypes.`application/json`
+    val requestEntity = initiateMultipartUploadRequest(S3Location("test-bucket", "test-key"), Metadata(contentType = customContentType)).entity
+
+    requestEntity.contentType shouldBe customContentType
+  }
+
+  "uploadPartRequest" should "set the default entity contentType when it is not specified" in {
+    val requestEntity = uploadPartRequest(MultipartUpload(S3Location("test-bucket", "test-key"), "my-upload-id"), 1, ByteString.empty, Metadata()).entity
+
+    requestEntity.contentType shouldBe ContentTypes.`application/octet-stream`
+  }
+
+  it should "set the custom entity contentType when it is specified" in {
+    val customContentType = ContentTypes.`application/json`
+    val requestEntity = uploadPartRequest(MultipartUpload(S3Location("test-bucket", "test-key"), "my-upload-id"), 1, ByteString.empty, Metadata(contentType = customContentType)).entity
+
+    requestEntity.contentType shouldBe customContentType
+  }
+
+}

--- a/s3-stream/src/test/scala/com/bluelabs/s3stream/HttpRequestsSpec.scala
+++ b/s3-stream/src/test/scala/com/bluelabs/s3stream/HttpRequestsSpec.scala
@@ -33,8 +33,12 @@ class HttpRequestsSpec extends FlatSpec with Matchers {
     metadataHeaders(Metadata(serverSideEncryption = ServerSideEncryption.Kms("my-id"))) should contain(`X-Amz-Server-Side-Encryption`(KMS))
   }
 
-  it should "add the x-amz-server-side-encryption-kms-id with KMZ header when the server side encryption is KMS" in {
+  it should "add the x-amz-server-side-encryption-kms-id when the server side encryption is KMS" in {
     metadataHeaders(Metadata(serverSideEncryption = ServerSideEncryption.Kms("my-id"))) should contain(`X-Amz-Server-Side-Encryption-Aws-Kms-Key-Id`("my-id"))
+  }
+
+  it should "add the x-amz-server-side-encryption-context when the server side encryption is KMS and context is not empty" in {
+    metadataHeaders(Metadata(serverSideEncryption = ServerSideEncryption.Kms("my-id", Map("foo"->"bar")))) should contain(`X-Amz-Server-Side-Encryption-Context`(Map("foo"->"bar")))
   }
 
   "initiateMultipartUploadRequest" should "set the default entity contentType when it is not specified" in {


### PR DESCRIPTION
This PR fixes #16 and #2. It introduces the `Metadata` class to hold information about the content type and server side encryption.

It also models the server side encryption AWS headers.
